### PR TITLE
Add basic join support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ mod tests {
         let df = ctx.sql(sql).await?;
         let plan = df.to_logical_plan()?;
         let proto = to_substrait_rel(&plan)?;
+
+        // pretty print the protobuf struct
+        println!("{:#?}", proto);
+
         let df = from_substrait_rel(&mut ctx, &proto).await?;
         let plan2 = df.to_logical_plan()?;
         let plan2 = ctx.optimize(&plan2)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[tokio::test]
     async fn trivial_inner_join() -> Result<()> {
-        roundtrip("SELECT data.a FROM data JOIN data data2 ON data.a = data2.a").await
+        roundtrip("SELECT data.a FROM data JOIN data2 ON data.a = data2.a").await
     }
 
     async fn roundtrip(sql: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,20 +34,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trivial_inner_join() -> Result<()> {
+    async fn roundtrip_inner_join() -> Result<()> {
         roundtrip("SELECT data.a FROM data JOIN data2 ON data.a = data2.a").await
     }
 
-    async fn roundtrip(sql: &str) -> Result<()> {
-        let mut ctx = SessionContext::new();
-        ctx.register_csv("data", "testdata/data.csv", CsvReadOptions::new())
-            .await?;
-        ctx.register_csv("data2", "testdata/data.csv", CsvReadOptions::new())
-            .await?;
+    #[tokio::test]
+    async fn inner_join() -> Result<()> {
+        assert_expected_plan(
+            "SELECT data.a FROM data JOIN data2 ON data.a = data2.a",
+            "Projection: #data.a\
+            \n  Inner Join: #data.a = #data2.a\
+            \n    TableScan: data projection=[a]\
+            \n    TableScan: data2 projection=[a]",
+        )
+        .await
+    }
+
+    async fn assert_expected_plan(sql: &str, expected_plan_str: &str) -> Result<()> {
+        let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.to_logical_plan()?;
-        //println!("Input Plan:\n{:?}", plan);
-
+        let proto = to_substrait_rel(&plan)?;
+        let df = from_substrait_rel(&mut ctx, &proto).await?;
+        let plan2 = df.to_logical_plan()?;
+        let plan2str = format!("{:?}", plan2);
+        assert_eq!(expected_plan_str, &plan2str);
+        Ok(())
+    }
+    async fn roundtrip(sql: &str) -> Result<()> {
+        let mut ctx = create_context().await?;
+        let df = ctx.sql(sql).await?;
+        let plan = df.to_logical_plan()?;
         let proto = to_substrait_rel(&plan)?;
 
         // pretty print the protobuf struct
@@ -57,12 +74,18 @@ mod tests {
         let plan2 = df.to_logical_plan()?;
         //println!("Roundtrip Plan:\n{:?}", plan2);
 
-        let plan2 = ctx.optimize(&plan2)?;
-        //println!("Optimized Roundtrip Plan:\n{:?}", plan2);
-
         let plan1str = format!("{:?}", plan);
         let plan2str = format!("{:?}", plan2);
         assert_eq!(plan1str, plan2str);
         Ok(())
+    }
+
+    async fn create_context() -> Result<SessionContext> {
+        let ctx = SessionContext::new();
+        ctx.register_csv("data", "testdata/data.csv", CsvReadOptions::new())
+            .await?;
+        ctx.register_csv("data2", "testdata/data.csv", CsvReadOptions::new())
+            .await?;
+        Ok(ctx)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,14 +46,20 @@ mod tests {
             .await?;
         let df = ctx.sql(sql).await?;
         let plan = df.to_logical_plan()?;
+        //println!("Input Plan:\n{:?}", plan);
+
         let proto = to_substrait_rel(&plan)?;
 
         // pretty print the protobuf struct
-        println!("{:#?}", proto);
+        //println!("{:#?}", proto);
 
         let df = from_substrait_rel(&mut ctx, &proto).await?;
         let plan2 = df.to_logical_plan()?;
+        //println!("Roundtrip Plan:\n{:?}", plan2);
+
         let plan2 = ctx.optimize(&plan2)?;
+        //println!("Optimized Roundtrip Plan:\n{:?}", plan2);
+
         let plan1str = format!("{:?}", plan);
         let plan2str = format!("{:?}", plan2);
         assert_eq!(plan1str, plan2str);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,16 @@ mod tests {
         roundtrip("SELECT * FROM data WHERE d AND a > 1").await
     }
 
+    #[tokio::test]
+    async fn trivial_inner_join() -> Result<()> {
+        roundtrip("SELECT data.a FROM data JOIN data data2 ON data.a = data2.a").await
+    }
+
     async fn roundtrip(sql: &str) -> Result<()> {
         let mut ctx = SessionContext::new();
         ctx.register_csv("data", "testdata/data.csv", CsvReadOptions::new())
+            .await?;
+        ctx.register_csv("data2", "testdata/data.csv", CsvReadOptions::new())
             .await?;
         let df = ctx.sql(sql).await?;
         let plan = df.to_logical_plan()?;


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-substrait/issues/14

This adds basic join support and also fixes a bug where we were not respecting table scan projections in the consumer.