### PR TITLE
Changed field reference from mask to direct reference

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -14,7 +14,10 @@ use datafusion::{
 use substrait::protobuf::{
     aggregate_function::AggregationInvocation,
     expression::{
-        field_reference::ReferenceType::MaskedReference, literal::LiteralType, MaskExpression,
+        field_reference::ReferenceType::DirectReference,
+        literal::LiteralType,
+        MaskExpression,
+        reference_segment::ReferenceType::StructField,
         RexType,
     },
     extensions::simple_extension_declaration::MappingType,
@@ -384,16 +387,16 @@ pub async fn from_substrait_agg_func(
 pub async fn from_substrait_rex(e: &Expression, input_schema: &DFSchema, extensions: &HashMap<u32, &String>) -> Result<Arc<Expr>> {
     match &e.rex_type {
         Some(RexType::Selection(field_ref)) => match &field_ref.reference_type {
-            Some(MaskedReference(mask)) => match &mask.select.as_ref() {
-                Some(x) if x.struct_items.len() == 1 => Ok(Arc::new(Expr::Column(Column {
+            Some(DirectReference(direct)) => match &direct.reference_type.as_ref() {
+                Some(StructField(x)) => Ok(Arc::new(Expr::Column(Column {
                     relation: None,
                     name: input_schema
-                        .field(x.struct_items[0].field as usize)
+                        .field(x.field as usize)
                         .name()
                         .to_string(),
                 }))),
                 _ => Err(DataFusionError::NotImplemented(
-                    "invalid field reference".to_string(),
+                    "direct reference with types other than StructField is not supported".to_string(),
                 )),
             },
             _ => Err(DataFusionError::NotImplemented(

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -14,7 +14,8 @@ use substrait::protobuf::{
         field_reference::ReferenceType,
         literal::LiteralType,
         mask_expression::{StructItem, StructSelect},
-        FieldReference, Literal, MaskExpression, RexType, ScalarFunction,
+        reference_segment,
+        FieldReference, Literal, MaskExpression, ReferenceSegment, RexType, ScalarFunction,
     },
     extensions::{self, simple_extension_declaration::{MappingType, ExtensionFunction}},
     function_argument::ArgType,
@@ -434,14 +435,13 @@ fn substrait_sort_field(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut 
 fn substrait_field_ref(index: usize) -> Result<Expression> {
     Ok(Expression {
         rex_type: Some(RexType::Selection(Box::new(FieldReference {
-            reference_type: Some(ReferenceType::MaskedReference(MaskExpression {
-                select: Some(StructSelect {
-                    struct_items: vec![StructItem {
+            reference_type: Some(ReferenceType::DirectReference(ReferenceSegment {
+                reference_type: Some(reference_segment::ReferenceType::StructField(
+                    Box::new(reference_segment::StructField {
                         field: index as i32,
                         child: None,
-                    }],
-                }),
-                maintain_singular_struct: false,
+                    }),
+                )),
             })),
             root_type: None,
         }))),


### PR DESCRIPTION
## Details
- Changed `FieldReference` from accessing columns via a `MaskedReference` expression to `DirectReference` expression, since each expression access a single column so repeated field is not necessary (ref: [consumer](https://github.com/substrait-io/substrait-java/blob/main/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java#L35-L84), [producer](https://github.com/substrait-io/substrait-java/blob/main/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java#L320-L366))

## Note
- We do not support `StructField` with child yet
- We only support `ReferenceSegment` with `StructField` type