### PR TITLE
Implement SELECT DISTINCT

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -91,9 +91,9 @@ pub async fn from_substrait_plan(ctx: &mut SessionContext, plan: &Plan) -> Resul
                     substrait::protobuf::plan_rel::RelType::Rel(rel) => {
                         Ok(from_substrait_rel(ctx, &rel, &function_extension).await?)
                     },
-                    substrait::protobuf::plan_rel::RelType::Root(_) => Err(DataFusionError::NotImplemented(
-                        "RootRel not supported".to_string()
-                    )),
+                    substrait::protobuf::plan_rel::RelType::Root(root) => {
+                        Ok(from_substrait_rel(ctx, &root.input.as_ref().unwrap(), &function_extension).await?)
+                    }
                 },
                 None => Err(DataFusionError::Internal("Cannot parse plan relation: None".to_string()))
             }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -75,6 +75,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn simple_distinct() -> Result<()> {
+        test_alias(
+            "SELECT * FROM (SELECT distinct a FROM data)", // `SELECT *` is used to add `projection` at the root
+            "SELECT a FROM data GROUP BY a",
+        ).await
+    }
+
+    #[tokio::test]
+    async fn select_distinct_two_fields() -> Result<()> {
+        test_alias(
+            "SELECT * FROM (SELECT distinct a, b FROM data)", // `SELECT *` is used to add `projection` at the root
+            "SELECT a, b FROM data GROUP BY a, b",
+        ).await
+    }
+
+    #[tokio::test]
     async fn simple_alias() -> Result<()> {
         test_alias(
             "SELECT d1.a, d1.b FROM data d1",


### PR DESCRIPTION
## Details

- Add support for `select distinct` (producer, tests)
  - Only changes to producer was implemented since we're using `aggregate` with no measure to represent `select distinct`
- Add support for plan starting with `RelRoot`. This allows the output column names to be included in the Substrait plan