### PR TITLE
Implement BETWEEN

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -371,17 +371,17 @@ pub fn make_binary_op_scalar_func(lhs: &Expression, rhs: &Expression, op: Operat
 pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut (Vec<extensions::SimpleExtensionDeclaration>, HashMap<String, u32>)) -> Result<Expression> {
     match expr {
         Expr::Between { expr, negated, low, high } => {
-            let l_expr;
-            let r_expr;
             match negated {
                 true => {
-                    // `expr NOT BETWEEN low AND high` can be translated into (expr < low AND high < expr)
+                    // `expr NOT BETWEEN low AND high` can be translated into (expr < low OR high < expr)
                     let substriat_expr = to_substrait_rex(expr, schema, extension_info)?;
                     let substrait_low = to_substrait_rex(low, schema, extension_info)?;
                     let substrait_high = to_substrait_rex(high, schema, extension_info)?;
 
-                    l_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_low, Operator::Lt, extension_info);
-                    r_expr = make_binary_op_scalar_func(&substrait_high, &substriat_expr, Operator::Lt, extension_info);
+                    let l_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_low, Operator::Lt, extension_info);
+                    let r_expr = make_binary_op_scalar_func(&substrait_high, &substriat_expr, Operator::Lt, extension_info);
+
+                    Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::Or, extension_info))
                 }
                 false => {
                     // `expr BETWEEN low AND high` can be translated into (low <= expr AND expr <= high)
@@ -389,11 +389,12 @@ pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut 
                     let substrait_low = to_substrait_rex(low, schema, extension_info)?;
                     let substrait_high = to_substrait_rex(high, schema, extension_info)?;
 
-                    l_expr = make_binary_op_scalar_func(&substrait_low, &substriat_expr, Operator::LtEq, extension_info);
-                    r_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_high, Operator::LtEq, extension_info);
+                    let l_expr = make_binary_op_scalar_func(&substrait_low, &substriat_expr, Operator::LtEq, extension_info);
+                    let r_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_high, Operator::LtEq, extension_info);
+
+                    Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::And, extension_info))
                 }
             }
-            Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::And, extension_info))
         }
         Expr::Column(col) => {
             let index = schema.index_of_column(&col)?;

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -347,9 +347,54 @@ fn _register_function(function_name: String, extension_info: &mut (Vec<extension
 
 }
 
+pub fn make_binary_op_scalar_func(lhs: &Expression, rhs: &Expression, op: Operator, extension_info: &mut (Vec<extensions::SimpleExtensionDeclaration>, HashMap<String, u32>)) -> Expression {
+    let function_name = operator_to_name(op).to_string().to_lowercase();
+    let function_anchor = _register_function(function_name, extension_info);
+    Expression {
+        rex_type: Some(RexType::ScalarFunction(ScalarFunction {
+            function_reference: function_anchor,
+            arguments: vec![
+                FunctionArgument {
+                    arg_type: Some(ArgType::Value(lhs.clone())),
+                },
+                FunctionArgument {
+                    arg_type: Some(ArgType::Value(rhs.clone())),
+                },
+            ],
+            output_type: None,
+            args: vec![],
+        })),
+    }
+}
+
 /// Convert DataFusion Expr to Substrait Rex
 pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut (Vec<extensions::SimpleExtensionDeclaration>, HashMap<String, u32>)) -> Result<Expression> {
     match expr {
+        Expr::Between { expr, negated, low, high } => {
+            let l_expr;
+            let r_expr;
+            match negated {
+                true => {
+                    // `expr NOT BETWEEN low AND high` can be translated into (expr < low AND high < expr)
+                    let substriat_expr = to_substrait_rex(expr, schema, extension_info)?;
+                    let substrait_low = to_substrait_rex(low, schema, extension_info)?;
+                    let substrait_high = to_substrait_rex(high, schema, extension_info)?;
+
+                    l_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_low, Operator::Lt, extension_info);
+                    r_expr = make_binary_op_scalar_func(&substrait_high, &substriat_expr, Operator::Lt, extension_info);
+                }
+                false => {
+                    // `expr BETWEEN low AND high` can be translated into (low <= expr AND expr <= high)
+                    let substriat_expr = to_substrait_rex(expr, schema, extension_info)?;
+                    let substrait_low = to_substrait_rex(low, schema, extension_info)?;
+                    let substrait_high = to_substrait_rex(high, schema, extension_info)?;
+
+                    l_expr = make_binary_op_scalar_func(&substrait_low, &substriat_expr, Operator::LtEq, extension_info);
+                    r_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_high, Operator::LtEq, extension_info);
+                }
+            }
+            Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::And, extension_info))
+        }
         Expr::Column(col) => {
             let index = schema.index_of_column(&col)?;
             substrait_field_ref(index)

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -376,29 +376,26 @@ pub fn make_binary_op_scalar_func(lhs: &Expression, rhs: &Expression, op: Operat
 pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut (Vec<extensions::SimpleExtensionDeclaration>, HashMap<String, u32>)) -> Result<Expression> {
     match expr {
         Expr::Between { expr, negated, low, high } => {
-            match negated {
-                true => {
-                    // `expr NOT BETWEEN low AND high` can be translated into (expr < low OR high < expr)
-                    let substriat_expr = to_substrait_rex(expr, schema, extension_info)?;
-                    let substrait_low = to_substrait_rex(low, schema, extension_info)?;
-                    let substrait_high = to_substrait_rex(high, schema, extension_info)?;
+            if *negated {
+                // `expr NOT BETWEEN low AND high` can be translated into (expr < low OR high < expr)
+                let substrait_expr = to_substrait_rex(expr, schema, extension_info)?;
+                let substrait_low = to_substrait_rex(low, schema, extension_info)?;
+                let substrait_high = to_substrait_rex(high, schema, extension_info)?;
 
-                    let l_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_low, Operator::Lt, extension_info);
-                    let r_expr = make_binary_op_scalar_func(&substrait_high, &substriat_expr, Operator::Lt, extension_info);
+                let l_expr = make_binary_op_scalar_func(&substrait_expr, &substrait_low, Operator::Lt, extension_info);
+                let r_expr = make_binary_op_scalar_func(&substrait_high, &substrait_expr, Operator::Lt, extension_info);
 
-                    Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::Or, extension_info))
-                }
-                false => {
-                    // `expr BETWEEN low AND high` can be translated into (low <= expr AND expr <= high)
-                    let substriat_expr = to_substrait_rex(expr, schema, extension_info)?;
-                    let substrait_low = to_substrait_rex(low, schema, extension_info)?;
-                    let substrait_high = to_substrait_rex(high, schema, extension_info)?;
+                Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::Or, extension_info))
+            } else {
+                // `expr BETWEEN low AND high` can be translated into (low <= expr AND expr <= high)
+                let substrait_expr = to_substrait_rex(expr, schema, extension_info)?;
+                let substrait_low = to_substrait_rex(low, schema, extension_info)?;
+                let substrait_high = to_substrait_rex(high, schema, extension_info)?;
 
-                    let l_expr = make_binary_op_scalar_func(&substrait_low, &substriat_expr, Operator::LtEq, extension_info);
-                    let r_expr = make_binary_op_scalar_func(&substriat_expr, &substrait_high, Operator::LtEq, extension_info);
+                let l_expr = make_binary_op_scalar_func(&substrait_low, &substrait_expr, Operator::LtEq, extension_info);
+                let r_expr = make_binary_op_scalar_func(&substrait_expr, &substrait_high, Operator::LtEq, extension_info);
 
-                    Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::And, extension_info))
-                }
+                Ok(make_binary_op_scalar_func(&l_expr, &r_expr, Operator::And, extension_info))
             }
         }
         Expr::Column(col) => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -92,6 +92,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn between_integers() -> Result<()> {
+        test_alias(
+            "SELECT * FROM data WHERE a BETWEEN 2 AND 6",
+            "SELECT * FROM data WHERE a >= 2 AND a <= 6"
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn not_between_integers() -> Result<()> {
+        test_alias(
+            "SELECT * FROM data WHERE a NOT BETWEEN 2 AND 6",
+            "SELECT * FROM data WHERE a < 2 OR a > 6"
+        )
+        .await
+    }
+
+    #[tokio::test]
     async fn roundtrip_inner_join() -> Result<()> {
         roundtrip("SELECT data.a FROM data JOIN data2 ON data.a = data2.a").await
     }


### PR DESCRIPTION
## Details

- Add support for `BETWEEN` in producer
- Refactor binary op scalar function creation into a function

## Notes
We do not need to add anything on the consumer side since:
- `expr NOT BETWEEN low AND high` can be translated into `expr < low OR high < expr`
- `expr BETWEEN low AND high` can be translated into `low <= expr AND expr <= high`

The converted expression type (binary op) is already supported by the consumer