### PR TITLE
Add case

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -408,6 +408,38 @@ pub async fn from_substrait_rex(e: &Expression, input_schema: &DFSchema, extensi
                 "unsupported field ref type".to_string(),
             )),
         },
+        Some(RexType::IfThen(if_then)) => {
+            // Parse `ifs`
+            // If the first element does not have a `then` part, then we can assume it's a base expression
+            let mut when_then_expr: Vec<(Box<Expr>, Box<Expr>)> = vec![];
+            let mut expr = None;
+            for (i, if_expr) in if_then.ifs.iter().enumerate() {
+                if i == 0 {
+                    // Check if the first element is type base expression
+                    match if_expr.then {
+                        Some(_) => (),
+                        None => {
+                            expr = Some(Box::new(from_substrait_rex(&if_expr.r#if.as_ref().unwrap(), input_schema, extensions).await?.as_ref().clone()));
+                            continue;
+                        },
+                    }
+                }
+                when_then_expr.push(
+                    (
+                        Box::new(from_substrait_rex(&if_expr.r#if.as_ref().unwrap(), input_schema, extensions).await?.as_ref().clone()),
+                        Box::new(from_substrait_rex(&if_expr.then.as_ref().unwrap(), input_schema, extensions).await?.as_ref().clone())
+                    ),
+                );
+            }
+            // Parse `else`
+            let else_expr = match &if_then.r#else {
+                Some(e) => Some(Box::new(
+                                                from_substrait_rex(&e, input_schema, extensions).await?.as_ref().clone(),
+                                            )),
+                None => None
+            };
+            Ok(Arc::new(Expr::Case { expr: expr, when_then_expr: when_then_expr, else_expr: else_expr }))
+        },
         Some(RexType::ScalarFunction(f)) => {
             assert!(f.arguments.len() == 2);
             let op = match extensions.get(&f.function_reference) {
@@ -459,7 +491,7 @@ pub async fn from_substrait_rex(e: &Expression, input_schema: &DFSchema, extensi
             Some(LiteralType::Fp64(f)) => {
                 Ok(Arc::new(Expr::Literal(ScalarValue::Float64(Some(*f)))))
             }
-            Some(LiteralType::String(s)) => Ok(Arc::new(Expr::Literal(ScalarValue::LargeUtf8(
+            Some(LiteralType::String(s)) => Ok(Arc::new(Expr::Literal(ScalarValue::Utf8(
                 Some(s.clone()),
             )))),
             Some(LiteralType::Binary(b)) => Ok(Arc::new(Expr::Literal(ScalarValue::Binary(Some(

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -416,12 +416,9 @@ pub async fn from_substrait_rex(e: &Expression, input_schema: &DFSchema, extensi
             for (i, if_expr) in if_then.ifs.iter().enumerate() {
                 if i == 0 {
                     // Check if the first element is type base expression
-                    match if_expr.then {
-                        Some(_) => (),
-                        None => {
-                            expr = Some(Box::new(from_substrait_rex(&if_expr.r#if.as_ref().unwrap(), input_schema, extensions).await?.as_ref().clone()));
-                            continue;
-                        },
+                    if if_expr.then.is_none() {
+                        expr = Some(Box::new(from_substrait_rex(&if_expr.r#if.as_ref().unwrap(), input_schema, extensions).await?.as_ref().clone()));
+                        continue;
                     }
                 }
                 when_then_expr.push(

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -435,14 +435,11 @@ pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut 
         Expr::Case { expr, when_then_expr, else_expr } => {
             let mut ifs: Vec<IfClause> = vec![];
             // Parse base
-            match expr {
-                Some(e) => { // Base expression exists
-                    ifs.push(IfClause {
-                        r#if: Some(to_substrait_rex(e, schema, extension_info)?),
-                        then: None,
-                    });
-                },
-                None => () // No base expression
+            if let Some(e) = expr { // Base expression exists
+                ifs.push(IfClause {
+                    r#if: Some(to_substrait_rex(e, schema, extension_info)?),
+                    then: None,
+                });
             }
             // Parse `when`s
             for (r#if, then) in when_then_expr {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -12,10 +12,11 @@ use substrait::protobuf::{
     aggregate_rel::{Grouping, Measure},
     expression::{
         field_reference::ReferenceType,
+        if_then::IfClause,
         literal::LiteralType,
         mask_expression::{StructItem, StructSelect},
         reference_segment,
-        FieldReference, Literal, MaskExpression, ReferenceSegment, RexType, ScalarFunction,
+        FieldReference, IfThen, Literal, MaskExpression, ReferenceSegment, RexType, ScalarFunction,
     },
     extensions::{self, simple_extension_declaration::{MappingType, ExtensionFunction}},
     function_argument::ArgType,
@@ -430,6 +431,39 @@ pub fn to_substrait_rex(expr: &Expr, schema: &DFSchemaRef, extension_info: &mut 
             let r = to_substrait_rex(right, schema, extension_info)?;
 
             Ok(make_binary_op_scalar_func(&l, &r, *op, extension_info))
+        }
+        Expr::Case { expr, when_then_expr, else_expr } => {
+            let mut ifs: Vec<IfClause> = vec![];
+            // Parse base
+            match expr {
+                Some(e) => { // Base expression exists
+                    ifs.push(IfClause {
+                        r#if: Some(to_substrait_rex(e, schema, extension_info)?),
+                        then: None,
+                    });
+                },
+                None => () // No base expression
+            }
+            // Parse `when`s
+            for (r#if, then) in when_then_expr {
+                ifs.push(IfClause {
+                    r#if: Some(to_substrait_rex(r#if, schema, extension_info)?),
+                    then: Some(to_substrait_rex(then, schema, extension_info)?),
+                });
+            }
+
+            // Parse outer `else`
+            let r#else: Option<Box<Expression>> = match else_expr {
+                Some(e) => Some(Box::new(to_substrait_rex(e, schema, extension_info)?)),
+                None => None,
+            };
+            
+            Ok(Expression {
+                rex_type: Some(RexType::IfThen(Box::new(IfThen {
+                    ifs: ifs,
+                    r#else: r#else
+                }))),
+            })
         }
         Expr::Literal(value) => {
             let literal_type = match value {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -126,6 +126,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn case_without_base_expression() -> Result<()> {
+        roundtrip("SELECT (CASE WHEN a >= 0 THEN 'positive' ELSE 'negative' END) FROM data").await
+    }
+
+    #[tokio::test]
+    async fn case_with_base_expression() -> Result<()> {
+        roundtrip("SELECT (CASE a WHEN 0 THEN 'zero' ELSE 'not-zero' END) FROM data").await
+    }
+
+    #[tokio::test]
     async fn roundtrip_inner_join() -> Result<()> {
         roundtrip("SELECT data.a FROM data JOIN data2 ON data.a = data2.a").await
     }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -132,7 +132,11 @@ mod tests {
 
     #[tokio::test]
     async fn case_with_base_expression() -> Result<()> {
-        roundtrip("SELECT (CASE a WHEN 0 THEN 'zero' ELSE 'not-zero' END) FROM data").await
+        roundtrip("SELECT (CASE a
+                            WHEN 0 THEN 'zero'
+                            WHEN 1 THEN 'one'
+                            ELSE 'other'
+                           END) FROM data").await
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Details
- Implement `CASE ... WHEN ...`
  - Consumer
  - Producer
  - Tests
 
## Notes
We're using `IfThen` expression for both `CASE` with AND without a base expression. This is because `IfThen` provides more flexibility in the `match` expression than `SwitchExpression`. Also, when translating back, `DataFusion` does not have `IfThen` expression. So we'll be treating all `CASE` translation as `DataFusion` `Expr::Case` <-> `Substrait` `RexType::IfThen`