### PR TITLE
feat: support explicit catalog/schema names in ReadRel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 datafusion = "13.0"
+datafusion-sql = "13.0"
 substrait = "0.2"
 tokio = "1.17"
 async-recursion = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 datafusion = "13.0"
-datafusion-sql = "13.0"
 substrait = "0.2"
 tokio = "1.17"
 async-recursion = "1.0"

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -11,7 +11,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-use datafusion_sql::TableReference;
+use datafusion::sql::TableReference;
 use substrait::protobuf::{
     aggregate_function::AggregationInvocation,
     expression::{

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -11,6 +11,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
+use datafusion_sql::TableReference;
 use substrait::protobuf::{
     aggregate_function::AggregationInvocation,
     expression::{
@@ -297,8 +298,26 @@ pub async fn from_substrait_rel(ctx: &mut SessionContext, rel: &Rel, extensions:
         }
         Some(RelType::Read(read)) => match &read.as_ref().read_type {
             Some(ReadType::NamedTable(nt)) => {
-                let table_name: String = nt.names[0].clone();
-                let t = ctx.table(&*table_name)?;
+                let table_reference = match nt.names.len() {
+                    0 => {
+                        return Err(DataFusionError::Internal(
+                            "No table name found in NamedTable".to_string(),
+                        ));
+                    }
+                    1 => TableReference::Bare {
+                        table: &nt.names[0],
+                    },
+                    2 => TableReference::Partial {
+                        schema: &nt.names[0],
+                        table: &nt.names[1],
+                    },
+                    _ => TableReference::Full {
+                        catalog: &nt.names[0],
+                        schema: &nt.names[1],
+                        table: &nt.names[2],
+                    },
+                };
+                let t = ctx.table(table_reference)?;
                 match &read.projection {
                     Some(MaskExpression { select, .. }) => match &select.as_ref() {
                         Some(projection) => {


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

This patch adds compatibility to let `ReadRel` specifies the catalog name and schema name explicitly. They were shipped in table name connected with `<catalog name>.<schema name>.<table name>`. 

By the way, I'm currently working on datafusion-substrait integration in [greptimedb](https://github.com/GreptimeTeam/greptimedb/tree/develop/src/common/substrait/src). To achieve rapid dev and iterate, I'm building it inside our repo. But I would like to donate to datafusion :heart:. Maybe this word is inappropriate because there is one already. Merge or combine is better? Anyway, please tell me what you think about it, appreciate it in advance!