### PR TITLE
ReadRel. Get column names from TableScan source

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -84,7 +84,8 @@ pub fn to_substrait_rel(
                         common: None,
                         base_schema: Some(NamedStruct {
                             names: scan
-                                .projected_schema
+                                .source
+                                .schema()
                                 .fields()
                                 .iter()
                                 .map(|f| f.name().to_owned())


### PR DESCRIPTION
## Details
Quick fix to list ALL columns from source table in `ReadRel` `base_schema`.

According to Substrait [documentation](https://substrait.io/relations/logical_relations/#read-properties), the `base_schema` (Direct Schema) property should contain all columns BEFORE projection or emit/hiding is applied.