### PR TITLE
Fix join type encoding and add tests

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -156,6 +156,21 @@ mod tests {
         )
         .await
     }
+    
+    #[tokio::test]
+    async fn roundtrip_left_join() -> Result<()> {
+        roundtrip("SELECT data.a FROM data LEFT JOIN data2 ON data.a = data2.a").await
+    }
+
+    #[tokio::test]
+    async fn roundtrip_right_join() -> Result<()> {
+        roundtrip("SELECT data.a FROM data RIGHT JOIN data2 ON data.a = data2.a").await
+    }
+
+    #[tokio::test]
+    async fn roundtrip_outer_join() -> Result<()> {
+        roundtrip("SELECT data.a FROM data FULL OUTER JOIN data2 ON data.a = data2.a").await
+    }
 
     async fn assert_expected_plan(sql: &str, expected_plan_str: &str) -> Result<()> {
         let mut ctx = create_context().await?;


### PR DESCRIPTION
## Details
- Add unit tests to test types other than inner join. These tests failed prior to implementation in this patch
- Fix the join type encoding bug. Previously, the encoding in the generated Subtrait plan does not align with the enum definition [here](https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto#L165-L176).