### PR TITLE
Upgrade to substrait 0.3

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           mkdir -p $HOME/d/protoc
           cd $HOME/d/protoc
-          export PROTO_ZIP="protoc-21.4-win64.zip"
+          export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
           unzip $PROTO_ZIP
           export PATH=$PATH:$HOME/d/protoc/bin

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -73,6 +73,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          export PATH=$PATH:$HOME/d/protoc/bin
           cargo build
 
   # test the crate

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -40,6 +40,9 @@ jobs:
         RUSTFLAGS: "-C debuginfo=1"
     steps:
       - uses: actions/checkout@v2
+      - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
@@ -59,21 +62,10 @@ jobs:
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
-      - name: Install protobuf compiler
-        shell: bash
-        run: |
-          mkdir -p $HOME/d/protoc
-          cd $HOME/d/protoc
-          export PROTO_ZIP="protoc-21.4-linux-x86_64.zip"
-          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
-          unzip $PROTO_ZIP
-          export PATH=$PATH:$HOME/d/protoc/bin
-          protoc --version
       - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          export PATH=$PATH:$HOME/d/protoc/bin
           cargo build
 
   # test the crate
@@ -95,6 +87,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
@@ -116,5 +111,4 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          export PATH=$PATH:$HOME/d/protoc/bin
           cargo test

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -59,6 +59,16 @@ jobs:
           rustup toolchain install ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}
           rustup component add rustfmt
+      - name: Install protobuf compiler
+        shell: bash
+        run: |
+          mkdir -p $HOME/d/protoc
+          cd $HOME/d/protoc
+          export PROTO_ZIP="protoc-21.4-win64.zip"
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
+          unzip $PROTO_ZIP
+          export PATH=$PATH:$HOME/d/protoc/bin
+          protoc.exe --version
       - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"
@@ -105,4 +115,5 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
+          export PATH=$PATH:$HOME/d/protoc/bin
           cargo test

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -68,7 +68,7 @@ jobs:
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.4/$PROTO_ZIP
           unzip $PROTO_ZIP
           export PATH=$PATH:$HOME/d/protoc/bin
-          protoc.exe --version
+          protoc --version
       - name: Build Workspace
         run: |
           export CARGO_HOME="/github/home/.cargo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bytes = "1.3.0"
 datafusion = "15.0"
 substrait = "0.3"
 tokio = "1.17"
 async-recursion = "1.0"
-prost = "0.9"
-prost-types = "0.9"
+prost = "0.11"
+prost-types = "0.11"
 
 [build-dependencies]
-prost-build = { version = "0.9" }
+prost-build = { version = "0.11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bytes = "1.3.0"
 datafusion = "15.0"
-substrait = "0.2"
+substrait = "0.3"
 tokio = "1.17"
 async-recursion = "1.0"
 prost = "0.9"

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -53,6 +53,7 @@ pub fn to_substrait_plan(plan: &LogicalPlan) -> Result<Box<Plan>> {
 
     // Return parsed plan
     Ok(Box::new(Plan {
+        version: None,
         extension_uris: vec![],
         extensions: function_extensions,
         relations: plan_rels,
@@ -104,6 +105,7 @@ pub fn to_substrait_rel(
                             names: vec![scan.table_name.clone()],
                             advanced_extension: None,
                         })),
+                        best_effort_filter: None,
                     }))),
                 }))
             } else {
@@ -354,6 +356,7 @@ pub fn to_substrait_agg_measure(
                     },
                     phase: substrait::protobuf::AggregationPhase::Unspecified as i32,
                     args: vec![],
+                    options: vec![],
                 }),
                 filter: match filter {
                     Some(f) => Some(to_substrait_rex(f, schema, extension_info)?),
@@ -452,6 +455,7 @@ pub fn make_binary_op_scalar_func(
             ],
             output_type: None,
             args: vec![],
+            options: vec![],
         })),
     }
 }


### PR DESCRIPTION
A new version of substrait-rs was just released, which picks up five months of work on the substrait proto files.