### PR TITLE
Add null equals null join

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tokio = "1.17"
 async-recursion = "1.0"
 prost = "0.11"
 prost-types = "0.11"
+itertools = "0.10.5"
 
 [build-dependencies]
 prost-build = { version = "0.11" }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -289,31 +289,45 @@ pub async fn from_substrait_rel(
             let on =
                 from_substrait_rex(&join.expression.as_ref().unwrap(), &schema, extensions).await?;
             let predicates = split_conjunction(&on);
-            let pairs: Vec<(Column, Column)> = predicates
+            // TODO: collect only one null_eq_null
+            let join_exprs: Vec<(Column, Column, bool)> = predicates
                 .iter()
                 .map(|p| match p {
-                    Expr::BinaryExpr(BinaryExpr {
-                        left,
-                        op: Operator::Eq,
-                        right,
-                    }) => match (left.as_ref(), right.as_ref()) {
-                        (Expr::Column(l), Expr::Column(r)) => Ok((l.clone(), r.clone())),
-                        _ => {
-                            return Err(DataFusionError::Internal(
-                                "invalid join condition".to_string(),
-                            ))
+                    Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+                        match (left.as_ref(), right.as_ref()) {
+                            (Expr::Column(l), Expr::Column(r)) => match op {
+                                Operator::Eq => Ok((l.clone(), r.clone(), false)),
+                                Operator::IsNotDistinctFrom => Ok((l.clone(), r.clone(), true)),
+                                _ => {
+                                    return Err(DataFusionError::Internal(
+                                        "invalid join condition op".to_string(),
+                                    ))
+                                }
+                            },
+                            _ => {
+                                return Err(DataFusionError::Internal(
+                                    "invalid join condition expresssion".to_string(),
+                                ))
+                            }
                         }
-                    },
+                    }
                     _ => {
                         return Err(DataFusionError::Internal(
-                            "invalid join condition".to_string(),
+                            "Non-binary expression is not supported in join condition".to_string(),
                         ))
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;
-            let (left_cols, right_cols): (Vec<_>, Vec<_>) = pairs.iter().cloned().unzip();
-            left.join(&right, join_type, (left_cols, right_cols), None)?
-                .build()
+            let (left_cols, right_cols, null_eq_nulls): (Vec<_>, Vec<_>, Vec<_>) =
+                itertools::multiunzip(join_exprs);
+            left.join_detailed(
+                &right,
+                join_type,
+                (left_cols, right_cols),
+                None,
+                null_eq_nulls[0],
+            )?
+            .build()
         }
         Some(RelType::Read(read)) => match &read.as_ref().read_type {
             Some(ReadType::NamedTable(nt)) => {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use datafusion::logical_expr::{Between, BinaryExpr, Case};
 use datafusion::{
@@ -225,11 +225,6 @@ pub fn to_substrait_rel(
             let right = to_substrait_rel(join.right.as_ref(), extension_info)?;
             let join_type = to_substrait_jointype(join.join_type)?;
             // we only support basic joins so return an error for anything not yet supported
-            if join.null_equals_null {
-                return Err(DataFusionError::NotImplemented(
-                    "join null_equals_null".to_string(),
-                ));
-            }
             if join.filter.is_some() {
                 return Err(DataFusionError::NotImplemented("join filter".to_string()));
             }
@@ -242,15 +237,34 @@ pub fn to_substrait_rel(
                 }
             }
             // map the left and right columns to binary expressions in the form `l = r`
-            let join_expression: Vec<Expr> = join
-                .on
-                .iter()
-                .map(|(l, r)| Expr::Column(l.clone()).eq(Expr::Column(r.clone())))
-                .collect();
+            let join_expression: Vec<Expr>;
+            if join.null_equals_null {
+                join_expression = join
+                    .on
+                    .iter()
+                    .map(|(l, r)| {
+                        Expr::BinaryExpr(BinaryExpr {
+                            left: Box::new(Expr::Column(l.clone())),
+                            op: Operator::IsNotDistinctFrom,
+                            right: Box::new(Expr::Column(r.clone())),
+                        })
+                    })
+                    .collect();
+            } else {
+                join_expression = join
+                    .on
+                    .iter()
+                    .map(|(l, r)| Expr::Column(l.clone()).eq(Expr::Column(r.clone())))
+                    .collect();
+            }
             // build a single expression for the ON condition, such as `l.a = r.a AND l.b = r.b`
             let join_expression = join_expression
                 .into_iter()
                 .reduce(|acc: Expr, expr: Expr| acc.and(expr));
+            // join schema from left and right to maintain all columns from inputs
+            // note that we cannot simple use join.schema here since we discard some input columns
+            // when performing semi and anti joins
+            let join_schema = join.left.schema().join(join.right.schema());
             if let Some(e) = join_expression {
                 Ok(Box::new(Rel {
                     rel_type: Some(RelType::Join(Box::new(JoinRel {
@@ -260,7 +274,7 @@ pub fn to_substrait_rel(
                         r#type: join_type as i32,
                         expression: Some(Box::new(to_substrait_rex(
                             &e,
-                            &join.schema,
+                            &Arc::new(join_schema?),
                             extension_info,
                         )?)),
                         post_join_filter: None,
@@ -579,6 +593,7 @@ pub fn to_substrait_rex(
                 ScalarValue::Int16(Some(n)) => Some(LiteralType::I16(*n as i32)),
                 ScalarValue::Int32(Some(n)) => Some(LiteralType::I32(*n)),
                 ScalarValue::Int64(Some(n)) => Some(LiteralType::I64(*n)),
+                ScalarValue::UInt8(Some(n)) => Some(LiteralType::I16(*n as i32)), // Substrait currently does not support unsigned integer
                 ScalarValue::Boolean(Some(b)) => Some(LiteralType::Boolean(*b)),
                 ScalarValue::Float32(Some(f)) => Some(LiteralType::Fp32(*f)),
                 ScalarValue::Float64(Some(f)) => Some(LiteralType::Fp64(*f)),

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -193,6 +193,19 @@ mod tests {
     async fn roundtrip_outer_join() -> Result<()> {
         roundtrip("SELECT data.a FROM data FULL OUTER JOIN data2 ON data.a = data2.a").await
     }
+    #[tokio::test]
+    async fn simple_intersect() -> Result<()> {
+        assert_expected_plan(
+            "SELECT COUNT(*) FROM (SELECT data.a FROM data INTERSECT SELECT data2.a FROM data2);",
+            "Projection: COUNT(Int16(1))\
+            \n  Aggregate: groupBy=[[]], aggr=[[COUNT(Int16(1))]]\
+            \n    LeftSemi Join: data.a = data2.a\
+            \n      Aggregate: groupBy=[[data.a]], aggr=[[]]\
+            \n        Projection: data.a\n          TableScan: data projection=[a]\
+            \n      Projection: data2.a\n        TableScan: data2 projection=[a]",
+        )
+        .await
+    }
 
     async fn assert_expected_plan(sql: &str, expected_plan_str: &str) -> Result<()> {
         let mut ctx = create_context().await?;
@@ -248,11 +261,11 @@ mod tests {
         let mut ctx = create_context().await?;
         let df = ctx.sql(sql).await?;
         let plan = df.to_logical_plan()?;
+        println!("{:#?}", plan);
+
         let proto = to_substrait_plan(&plan)?;
         let plan2 = from_substrait_plan(&mut ctx, &proto).await?;
         let plan2 = ctx.optimize(&plan2)?;
-
-        println!("{:#?}", plan);
         println!("{:#?}", plan2);
 
         let plan1str = format!("{:?}", plan);


### PR DESCRIPTION
## Details
- Implement `null_equals_null` join (producer, consumer, test: `INTERSECT`)
- Fix join schema (semi and anti) bug
  - The original code passes `join` output schema to `to_substrait_rex()`. This results in schema error since the right columns get discarded. The fix pass in a joined schema from `left` and `right` inputs of `join`
- Add `UInt8` to list of literal expression. Since Substrait does not directly support unsigned integers, we convert `UInt8` into `I16`